### PR TITLE
transactionがない状態（初回）で、何も帰ってこない問題

### DIFF
--- a/apps/line_bot/controllers/callback/create_reply_message.rb
+++ b/apps/line_bot/controllers/callback/create_reply_message.rb
@@ -144,7 +144,7 @@ class CreateReplyMessage < LineManager
     transaction_repository = RecommendTransactionRepository.new
 
     transaction = transaction_repository.find_by_user_id(user_id)
-    return transaction_repository.create(user_id: user_id) if transaction.nil?
+    return transaction_repository.create(user_id: user_id).to_h if transaction.nil?
 
     transaction
   end


### PR DESCRIPTION
https://github.com/yuuis/kiga-kiku/blob/6767d06777ae0a1cce60a59c887cef1cffd1721d/apps/line_bot/controllers/callback/create_reply_message.rb#L143-L147

`find_by_user_id` の返り値が
```ruby
{:id=>20, :user_id=>4, :created_at=>2019-07-06 10:00:40 UTC, :updated_at=>2019-07-06 10:00:40 UTC}
```
の様なHashであるのに対し、`create` の返り値が

```ruby
#<RecommendTransaction:0x00005644cd2d65c8 @attributes={:id=>21, :user_id=>4, :created_at=>2019-07-06 10:06:04 UTC, :updated_at=>2019-07-06 10:06:04 UTC}>
```
となっていて、ハッシュではない為 `transaction.id` の様に使用する。その為、

https://github.com/yuuis/kiga-kiku/blob/4f494278783b1bec1effbca526478b25b421ca35/lib/kiku/repositories/recommend_conversation_repository.rb#L8-L10
ここの部分の`transaction[:id]` でエラーが発生していた。

`to_h`でhashにする事で解消させた。
